### PR TITLE
Enhancing media controlling through playerctl

### DIFF
--- a/autostart.lua
+++ b/autostart.lua
@@ -32,6 +32,9 @@ run_once("blueman-applet")
 run_once("picom --experimental-backends --config " ..
              gears.filesystem.get_configuration_dir() .. "configs/picom.conf")
 
+--Media controller daemon
+run_once("playerctld daemon")
+
 return autostart
 
 -- EOF ------------------------------------------------------------------------

--- a/keys.lua
+++ b/keys.lua
@@ -95,7 +95,13 @@ globalkeys = gears.table.join( -- Focus client by direction (arrow keys)
                            function() awful.spawn("pamixer -d 3") end),
                  awful.key({}, "XF86AudioMute",
                            function() awful.spawn("pamixer -t") end),
-
+    --Media Control
+                 awful.key({},"XF86AudioPlay",
+                           function() awful.spawn("playerctl play-pause")end),
+                 awful.key({},"XF86AudioPrev",
+                           function() awful.spawn("playerctl previous")end),
+                 awful.key({},"XF86AudioNext",
+                           function() awful.spawn("playerctl next")end),
     -- Screen Shots/Vids
                  awful.key({}, "Print", function()
         awful.spawn.with_shell(gears.filesystem.get_configuration_dir() ..


### PR DESCRIPTION
Hey,
I've enabled the playerctl dameon to run at startup, in this way  Playerctl will act on players in order of their last activity which is more natural for the user, also I've added the key shortcuts for passing songs as you do with the spotify widget.
Thanks a lot for sharing your dots. :) 